### PR TITLE
fix TV-173 for offline messages from retirements

### DIFF
--- a/src/app/components/pages/retirement/retirement-list/retirement-list-item/retirement-list-item.component.html
+++ b/src/app/components/pages/retirement/retirement-list/retirement-list-item/retirement-list-item.component.html
@@ -18,6 +18,7 @@
       {{retirement.getDateInterval()}}<br/>
       {{retirement.places_remaining}} {{ 'retirement-list-item.place_availables' | translate }}
     </p>
+    <app-alert [type]="'text-warning'" [messages]="getMessageAlert()"></app-alert>
 
     <div *ngIf="showDetails" class="retirement-list-item__description__more">
       <b>{{ 'retirement-list-item.begin' | translate }}:</b> {{retirement.getStartTime()}}<br/>

--- a/src/app/components/pages/retirement/retirement-list/retirement-list-item/retirement-list-item.component.ts
+++ b/src/app/components/pages/retirement/retirement-list/retirement-list-item/retirement-list-item.component.ts
@@ -90,4 +90,11 @@ export class RetirementListItemComponent implements OnInit {
       }
     );
   }
+
+  getMessageAlert(){
+    if (!this.authenticationService.isAuthenticated() && this.retirement.places_remaining <= 0) {
+      return [_('retirement-list-item.messageAlertWaitingList')];
+    }
+    return [_('retirement-cart.connexion.warning')];
+  }
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -369,6 +369,8 @@
   "retirement-list-item.begin": "Début",
   "retirement-list-item.end": "Fin",
   "retirement-list-item.know_more": "En savoir plus",
+  "retirement-list-item.messageAlertReservation": "Vous devez être connecté.e pour faire une réservation.",
+  "retirement-list-item.messageAlertWaitingList": "Vous devez vous connecter pour être sur notre liste d'attente",
   "retirement-list-item.notifications.subscribe_waiting_list.error.content": "Inscription échoué",
   "retirement-list-item.notifications.subscribe_waiting_list.error.title": "Erreur",
   "retirement-list-item.notifications.subscribe_waiting_list.success.content": "Vous êtes maintenant inscrit à la liste d'attente.",


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Fix]
| Tickets (_issues_) concerned               | [TV-173]

---

## What have you changed ?
ajout d'un message d’alerte pour faire comprendre aux utilisateurs qu'ils devraient se connecter avant de faire toutes actions sur les retraites. 

## How did you change it ?
ajout d'une fonction pour fournir un message adéquat d'alerte.

## Screenshots
![image (3)](https://user-images.githubusercontent.com/5290381/57726011-83187e00-765c-11e9-92d4-bcbbecd10f88.png)

## Verification :
 -  [X] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [X] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 


[TV-173]: https://fjnr-inc.atlassian.net/browse/TV-173