### PR TITLE
Fix user cant reserve timeslot without membership

### DIFF
--- a/src/app/components/pages/reservation-page/reservation-page.component.html
+++ b/src/app/components/pages/reservation-page/reservation-page.component.html
@@ -361,7 +361,7 @@
               maxWidth="600px"
               title="{{'reservation.how_to.title' | translate}}"
               [autoClose]="true"
-              [show]="needToShowTutorial()">
+              [show]="firstTimeReservation()">
   <p class="modal-reservation__text">
     {{'reservation.how_to.text_1' | translate}}:
   </p>

--- a/src/app/components/pages/reservation-page/reservation-page.component.ts
+++ b/src/app/components/pages/reservation-page/reservation-page.component.ts
@@ -553,7 +553,14 @@ export class ReservationPageComponent implements OnInit {
       expiredMembership = new Date(this.user.membership_end) < new Date();
     }
     const noMembershipInCart = isNull(this.selectedMembership);
-    return noMembershipInCart && (neverHadMembership || expiredMembership);
+
+    let benefitOfNewUserPromo = false;
+    if (this.firstTimeReservation()) {
+      if (this.selectedTimeSlots.length <= 1) {
+        benefitOfNewUserPromo = true;
+      }
+    }
+    return noMembershipInCart && !benefitOfNewUserPromo && (neverHadMembership || expiredMembership);
   }
 
   needToUseCard() {
@@ -639,7 +646,7 @@ export class ReservationPageComponent implements OnInit {
     return this.totalPrice + this.getTotalTPS() + this.getTotalTVQ();
   }
 
-  needToShowTutorial() {
+  firstTimeReservation() {
     if (isNull(this.listReservedTimeslot)) {
       return false;
     } else {

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -309,7 +309,7 @@
   "reservation.info_need_membership": "Les blocs de rédaction de cet espace de travail nécessitent un membership actif pour être réservées. Veuillez sélectionner un type de membership à acheter.",
   "reservation.info_need_package": "Il vous faut plus de blocs prépayés que ceux disponibles sur votre profil.",
   "reservation.membership_active": "Votre membership est encore valide",
-  "reservation.membership_inactive": "Votre n'avez pas de membership actif.",
+  "reservation.membership_inactive": "Vous n'avez pas de membership actif.",
   "reservation.membership_required": "membership requis",
   "reservation.n_bloc_prepayed": "Il vous reste {{numberOfTicket}} bloc(s) prépayé(s)",
   "reservation.need_to_login_1": "Pour réserver un bloc de rédaction dans un espace de travail vous devez d'abord",


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | [TV-191](https://fjnr-inc.atlassian.net/browse/TV-191)

---

## What have you changed ?
Allow user to make a first reservation to a workplace without membership. After the first one, people need to buy a membership.

## How did you change it ?
 - Add a condition on `needToBuyMembership()` method to check if user already made a reservation before or not.
 - Add a condition on `needToBuyMembership()` method to check if cart contain only 1 timeslot and no more

## Screenshots
No change of display

## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
