### PR TITLE
submit form on every click in admin>workplace>Modale formWorplace

### DIFF
--- a/src/app/components/pages/admin/workplaces/workplaces.component.ts
+++ b/src/app/components/pages/admin/workplaces/workplaces.component.ts
@@ -227,27 +227,25 @@ export class WorkplacesComponent implements OnInit {
   }
 
   submitWorkplace() {
-    if ( this.workplaceForm.valid ) {
-      const value = this.workplaceForm.value;
-      value['timezone'] = 'America/Montreal';
-      this.workplaceService.create(value).subscribe(
-        data => {
-          this.notificationService.success(
-            _('shared.notifications.commons.added.title')
-          );
-          this.refreshWorkplaceList();
-          this.toggleModal('form_workplaces');
-        },
-        err => {
-          if (err.error.non_field_errors) {
-            this.workplaceErrors = err.error.non_field_errors;
-          } else {
-            this.workplaceErrors =  ['shared.form.errors.unknown'];
-          }
-          this.workplaceForm = FormUtil.manageFormErrors(this.workplaceForm, err);
+    const value = this.workplaceForm.value;
+    value['timezone'] = 'America/Montreal';
+    this.workplaceService.create(value).subscribe(
+      data => {
+        this.notificationService.success(
+          _('shared.notifications.commons.added.title')
+        );
+        this.refreshWorkplaceList();
+        this.toggleModal('form_workplaces');
+      },
+      err => {
+        if (err.error.non_field_errors) {
+          this.workplaceErrors = err.error.non_field_errors;
+        } else {
+          this.workplaceErrors =  ['shared.form.errors.unknown'];
         }
-      );
-    }
+        this.workplaceForm = FormUtil.manageFormErrors(this.workplaceForm, err);
+      }
+    );
   }
 
   isSecurityOnDeletionValid() {


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Fix]
| Tickets (_issues_) concerned               | [https://fjnr-inc.atlassian.net/jira/software/projects/TV/boards/2?selectedIssue=TV-195]

---

## What have you changed ?
In admin panel, when the modal to create a workplace received an error, it became impossible to submit the form even after the errors were fixed.

## How did you change it ?
I removed the condition that prevented from submitting the form. It is the way it is done to create new retirement.

## Screenshots
...

## Verification :
 -  [ ] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [X] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 
