### PR TITLE
Update new-layout.component.scss

### DIFF
--- a/src/app/layouts/new-layout/new-layout.component.scss
+++ b/src/app/layouts/new-layout/new-layout.component.scss
@@ -7,7 +7,7 @@
 
   &__content {
     height: 100vh;
-    overflow-y: scroll;
+    overflow-y: auto;
     flex: 1;
   }
 


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | None

---

## What have you changed ?
Fix useless scroll bar on right side of some page

## How did you change it ?
Just change `scroll` scss value to `auto` in order to hide the scrollbar when useless

## Screenshots
**Page before**
You can see the useless scrollbar on the right border, just after the second scrollbar.

![Screenshot_2019-10-29 Thèsez-vous](https://user-images.githubusercontent.com/12053720/67804587-97fb9900-fa65-11e9-855b-cae54fbde355.png)

## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
