### PR TITLE
fix condition of queue to limit only if invitation AND reserved seat

### DIFF
--- a/src/app/components/shared/retreat-preview/retreat-preview.component.ts
+++ b/src/app/components/shared/retreat-preview/retreat-preview.component.ts
@@ -136,6 +136,6 @@ export class RetreatPreviewComponent implements OnInit {
   get display_wait_queue_button(){
     return this.displaySubscribeButton &&
       this.canSubscribeToWaitingQueue() &&
-      (this.invitation && !this.invitation.reserve_seat);
+      !(this.invitation && this.invitation.reserve_seat);
   }
 }


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | [TV-276](https://fjnr-inc.atlassian.net/browse/TV-276)

---

## What have you changed ?
Fix the condition to show waiting queue button

## How did you change it ?
Refactor again the condition

| Invitation | Reserved seats | Result
| -----| ------| ---
| 0 | 0 | No problem for us, its just a guy without invitation
| 0 | 1 | No problem for us, it's not even possible
| 1 | 0 | No problem, place are not reserved
| 1 | 1 | We don't want that!!

## Screenshots
None

## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
