### PR TITLE
add error message on modal to cancel retreat

### DIFF
--- a/src/app/components/pages/admin/retreat/retreat.component.html
+++ b/src/app/components/pages/admin/retreat/retreat.component.html
@@ -127,11 +127,19 @@
       {{ 'retreat.cancel_reservation_modal.refund' | translate }}
     </label>
   </div>
+
   <app-alert class="cancel_reservation_modal__alert" *ngIf="refundOnCancelReservation" type="warning" [messages]="['retreat.cancel_reservation_modal.warning_refund']"></app-alert>
+
   <div class="align-top">
     <input id="securityCheckbox" type="checkbox" [(ngModel)]="securityOnCancelReservation" />
     <label class="nt-form-label" for="securityCheckbox">
       {{ 'retreat.cancel_reservation_modal.security' | translate }}
     </label>
+  </div>
+
+  <div *ngIf="errors" >
+    <p></p>
+    <app-alert type="danger" [messages]="errors">
+    </app-alert>
   </div>
 </app-nt-modal>

--- a/src/app/components/pages/admin/retreat/retreat.component.ts
+++ b/src/app/components/pages/admin/retreat/retreat.component.ts
@@ -554,6 +554,9 @@ export class RetreatComponent implements OnInit {
           _('retreat.notifications.cancellation_success.title')
         );
         this.tableRetreat.refreshPeriodList();
+      },
+      err => {
+        this.errors = err.error.non_field_errors;
       }
     );
   }


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | None

---

## What have you changed ?
Add error message management on modal to cancel retreat as an admin

## How did you change it ?
Just add condition on `non_field_errors` from API

## Screenshots
None

## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
