### PR TITLE
fix ordering of retreat

### DIFF
--- a/src/app/components/pages/retreat/retreat-reservation/retreat-reservation.component.ts
+++ b/src/app/components/pages/retreat/retreat-reservation/retreat-reservation.component.ts
@@ -141,6 +141,10 @@ export class RetreatReservationComponent implements OnInit, OnDestroy {
         'name': 'hidden',
         'value': false
       },
+      {
+        'name': 'ordering',
+        'value': 'start_time'
+      }
     ];
     this.retreatService.list(filters).subscribe(
       data => {


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | [TV-307](https://fjnr-inc.atlassian.net/browse/TV-307)

---

## What have you changed ?
Fix ordering of retreat by start-date

## How did you change it ?
Add ordering params on retreat listing from API

## Screenshots
![Screenshot_2020-07-07 Thèsez-vous](https://user-images.githubusercontent.com/12053720/86801522-1a4f4a80-c042-11ea-9763-9eba720b12c4.png)


## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
