### PR TITLE
fix chartjs change /deep/ to ::nge-deep

### DIFF
--- a/src/app/components/shared/chart-js/chart-js.component.scss
+++ b/src/app/components/shared/chart-js/chart-js.component.scss
@@ -1,13 +1,13 @@
 @import "../../../../assets/scss/_theme.scss";
 
-/deep/ .mat-slide-toggle.mat-checked:not(.mat-disabled) .mat-slide-toggle-bar {
+::ng-deep .mat-slide-toggle.mat-checked:not(.mat-disabled) .mat-slide-toggle-bar {
   background-color: $nt-10;
 }
-/deep/ .mat-slide-toggle.mat-checked:not(.mat-disabled) .mat-slide-toggle-thumb {
+::ng-deep .mat-slide-toggle.mat-checked:not(.mat-disabled) .mat-slide-toggle-thumb {
   background-color: $nt-13;
 }
 
-/deep/ .mat-progress-spinner circle, .mat-spinner circle {
+::ng-deep .mat-progress-spinner circle, .mat-spinner circle {
   stroke: $nt-14;
 }
 


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | TV-316

---

## What have you changed ?
Repalce /deep/ by ::ng-deep on chartsjs component scss

## How did you change it ?
...

## Screenshots
...

## Verification :
 -  [ ] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [ ] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 
