### PR TITLE
set secondes to 0 when editing a period date

### DIFF
--- a/src/app/components/pages/admin/retreat-date/retreat-date.component.ts
+++ b/src/app/components/pages/admin/retreat-date/retreat-date.component.ts
@@ -169,7 +169,15 @@ export class RetreatDateComponent implements OnInit {
   submitDate() {
     if (this.selectedDate) {
 
-      const data = this.dateForm.value;
+      const data: RetreatDate = this.dateForm.value;
+
+      const start_date = new Date(data.start_time);
+      start_date.setSeconds(0);
+      data.start_time = start_date.toISOString();
+
+      const end_time = new Date(data.end_time);
+      end_time.setSeconds(0);
+      data.end_time = end_time.toISOString();
 
       this.retreatDateService
         .update(this.selectedDate.url, data).subscribe(
@@ -194,6 +202,14 @@ export class RetreatDateComponent implements OnInit {
 
       const date: RetreatDate = this.dateForm.value;
       date.retreat = this.retreat.url;
+
+      const start_date = new Date(date.start_time);
+      start_date.setSeconds(0);
+      date.start_time = start_date.toISOString();
+
+      const end_time = new Date(date.end_time);
+      end_time.setSeconds(0);
+      date.end_time = end_time.toISOString();
 
       this.retreatDateService
         .create(date).subscribe(

--- a/src/app/components/table/periods/table-periods.component.ts
+++ b/src/app/components/table/periods/table-periods.component.ts
@@ -179,8 +179,16 @@ export class TablePeriodsComponent implements OnInit {
   submitPeriod() {
     const request = this.periodForm.value;
 
+    const start_date = new Date(this.periodForm.value.start_date);
+    start_date.setSeconds(0);
+    request.start_date = start_date.toISOString();
+
+    const end_time = new Date(this.periodForm.value.end_date);
+    end_time.setSeconds(0);
+    request.end_date = end_time.toISOString();
+
     if (this.selectedPeriod) {
-      request['price'] = this.selectedPeriod.price;
+      request.price = this.selectedPeriod.price;
 
       this.periodService.update(this.selectedPeriod.url, request).subscribe(
         data => {


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | [TV-336](https://fjnr-inc.atlassian.net/browse/TV-336)

---

## What have you changed ?
Force secondes to 0 for retreat and timeslot

## How did you change it ?
...

## Screenshots
...

## Verification :
 -  [ ] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [ ] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 
