### PR TITLE
fix(retreat_invitation):change_button_information_section

### DIFF
--- a/src/app/components/pages/hidden-retreat/hidden-retreat.component.ts
+++ b/src/app/components/pages/hidden-retreat/hidden-retreat.component.ts
@@ -101,7 +101,7 @@ export class HiddenRetreatComponent implements OnInit, OnDestroy {
 
   redirectToRetreatInfo() {
     window.open(
-      'http://www.thesez-vous.com/questcequuneretraite.html',
+      'https://www.thesez-vous.com/services.html',
       '_blank',
     );
   }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -204,7 +204,7 @@
   "header.retreat.what_is_it": "Qu'est-ce?",
   "header.virtual_activities.title": "Services virtuels",
   "hidden-retreat.alert_success": "Le coupon {{code}} d'une valeur de {{value}}{{typeValue}} sera automatiquement appliqué lors de l'inscription à cette retraite.\n          Sa validation dans le panier (à l'étape du paiement) dépendra du nombre de personnes l'ayant déjà utilisé.",
-  "hidden-retreat.alert_success_btn": "Exemple d'horaire",
+  "hidden-retreat.alert_success_btn": "En savoir plus",
   "hidden-retreat.alert_success_title_1": "Thèsez-vous offre différents types d'activités de rédaction collective!",
   "hidden-retreat.alert_success_title_2": "L'hébergement, les repas et l'horaire sont pris en charge, il ne vous reste qu'à rédiger!",
   "hidden-retreat.alert_success_title_3": "Une retraite Thèsez-vous, c'est trois jours durant lesquels on combine plus de 20 heures de rédaction productive, des ateliers, des activités pour s'aérer l'esprit et des occasions de partager des ressources avec des étudiant.e.s de toutes les disciplines et de toutes les universités du Québec.",


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix 
| Tickets (_issues_) concerned               | [Ticket 2407](https://redmine.fjnr.ca/issues/2407)

---

## What have you changed ?
J'ai changé le nom du bouton de la section d'information d'une invitation de retraite et également le lien au quel le bouton renvoie (https://www.thesez-vous.com/services.html)

## How did you change it ?
Le fichier json en francais pour le texte.
La redirection du lien pour le nouveau lien

## Screenshots
Ancien visuel : 
![Changement titre Section retraite invitation (ancienne)](https://user-images.githubusercontent.com/62400768/106689551-27afc180-659e-11eb-81bc-70c7f2299f4f.PNG)

Nouveau visuel : 
![Changement bouton Section retraite invitation](https://user-images.githubusercontent.com/62400768/106689580-35fddd80-659e-11eb-9440-32286f97c6f7.PNG)


## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
