### PR TITLE
fix(error_message):change_text_error_message_full_retreat

### DIFF
--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -947,7 +947,7 @@
   "retreat-preview.location": "Lieu",
   "retreat-preview.other_informations": "Autres informations",
   "retreat-preview.rate": "Tarif (membre)",
-  "retreat-preview.room_no_available_retreat": "Il n'y a plus de place disponible pour cette retraite.",
+  "retreat-preview.room_no_available_retreat": "Il n'y a plus de place disponible pour cette activité.",
   "retreat-preview.space_available": "Place(s) disponible(s)",
   "retreat-preview.start": "Début",
   "retreat-preview.success": "Liste d'attente",


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | [Ticket 2352](https://redmine.fjnr.ca/issues/2352)

---

## What have you changed ?
Remplacer le terme "retraite" par "activité" dans le message d'erreur qui s'affiche si la retraite est pleine.

## How did you change it ?
Le fichier Json en francais uniquement

## Screenshots
Ancien visuel : ![Ancien Visuel Message d'erreur de retraite pleine](https://user-images.githubusercontent.com/62400768/106690411-c0930c80-659f-11eb-8823-0dbb148e3ec9.PNG)

Nouveau visuel : ![Nouveau Visuel Message d'erreur de retraite pleine](https://user-images.githubusercontent.com/62400768/106690415-c25cd000-659f-11eb-8959-aa99dcace397.PNG)

## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
