### PR TITLE
enhance calculation of tomatoes and loading of reservations

### DIFF
--- a/src/app/components/pages/profile/profile-timeslots/profile-timeslots.component.ts
+++ b/src/app/components/pages/profile/profile-timeslots/profile-timeslots.component.ts
@@ -7,7 +7,6 @@ import {WorkplaceService} from '../../../../services/workplace.service';
 import {_} from '@biesbjerg/ngx-translate-extract/dist/utils/utils';
 import {MyNotificationService} from '../../../../services/my-notification/my-notification.service';
 import {MyModalService} from '../../../../services/my-modal/my-modal.service';
-import {environment} from '../../../../../environments/environment';
 
 @Component({
   selector: 'app-profile-timeslots',
@@ -24,12 +23,6 @@ export class ProfileTimeslotsComponent implements OnInit {
   reservationInCancelation: Reservation = null;
 
   displayAll = false;
-
-  totalPastReservations = 0;
-  totalFutureReservations = 0;
-
-  @Output() totalPastTomatoes: EventEmitter<any> = new EventEmitter();
-  @Output() totalFutureTomatoes: EventEmitter<any> = new EventEmitter();
 
   constructor(private authenticationService: AuthenticationService,
               private reservationService: ReservationService,
@@ -73,23 +66,15 @@ export class ProfileTimeslotsComponent implements OnInit {
           r => new Reservation(r)
         );
 
-        this.totalPastReservations = 0;
-        this.totalFutureReservations = 0;
         this.listReservations = [];
         this.listFutureReservations = [];
 
         for ( const reservation of listReservations ) {
-          if (reservation.timeslot_details.getEndDate() < new Date()) {
-            this.totalPastReservations += environment.tomato_per_timeslot;
-          } else {
-            this.totalFutureReservations += environment.tomato_per_timeslot;
+          if (reservation.timeslot_details.getEndDate() >= new Date()) {
             this.listFutureReservations.push(reservation);
           }
           this.listReservations.push(reservation);
         }
-
-        this.totalPastTomatoes.emit(this.totalPastReservations);
-        this.totalFutureTomatoes.emit(this.totalFutureReservations);
       }
     );
   }

--- a/src/app/components/pages/profile/profile.component.html
+++ b/src/app/components/pages/profile/profile.component.html
@@ -45,15 +45,15 @@
         <div class="profile-page__body__content__right__separator"></div>
 
         <div class="profile-page__body__content__right__retreats">
-          <app-profile-retreats [type]='"virtual"' (openVirtualReservation)="openVirtualReservation = $event" (totalPastTomatoes)="totalPastVirtualRetreatTomatoes = $event" (totalFutureTomatoes)="totalFutureVirtualRetreatTomatoes = $event"></app-profile-retreats>
+          <app-profile-retreats [type]='"virtual"' (openVirtualReservation)="openVirtualReservation = $event"></app-profile-retreats>
         </div>
 
         <div class="profile-page__body__content__right__retreats">
-          <app-profile-retreats [type]='"physical"' (openVirtualReservation)="openVirtualReservation = $event" (totalPastTomatoes)="totalPastPhysicalRetreatTomatoes = $event" (totalFutureTomatoes)="totalFuturePhysicalRetreatTomatoes = $event"></app-profile-retreats>
+          <app-profile-retreats [type]='"physical"' (openVirtualReservation)="openVirtualReservation = $event"></app-profile-retreats>
         </div>
 
         <div class="profile-page__body__content__right__timeslots">
-          <app-profile-timeslots (totalPastTomatoes)="totalPastTimeslotTomatoes = $event" (totalFutureTomatoes)="totalFutureTimeslotTomatoes = $event"></app-profile-timeslots>
+          <app-profile-timeslots></app-profile-timeslots>
         </div>
       </div>
     </div>

--- a/src/app/components/pages/profile/profile.component.ts
+++ b/src/app/components/pages/profile/profile.component.ts
@@ -11,13 +11,6 @@ import {RetreatReservation} from '../../../models/retreatReservation';
 export class ProfileComponent implements OnInit {
 
   profile: User;
-
-  totalPastTimeslotTomatoes = 0;
-  totalFutureTimeslotTomatoes = 0;
-  totalPastPhysicalRetreatTomatoes = 0;
-  totalFuturePhysicalRetreatTomatoes = 0;
-  totalPastVirtualRetreatTomatoes = 0;
-  totalFutureVirtualRetreatTomatoes = 0;
   openVirtualReservation: RetreatReservation;
 
   constructor(private authenticationService: AuthenticationService) { }
@@ -31,10 +24,10 @@ export class ProfileComponent implements OnInit {
   }
 
   getTotalPastTomatoes() {
-    return this.totalPastTimeslotTomatoes + this.totalPastPhysicalRetreatTomatoes + this.totalPastVirtualRetreatTomatoes;
+    return this.profile.get_number_of_past_tomatoes;
   }
 
   getTotalFutureTomatoes() {
-    return this.totalFutureTimeslotTomatoes + this.totalFuturePhysicalRetreatTomatoes + this.totalFutureVirtualRetreatTomatoes;
+    return this.profile.get_number_of_future_tomatoes;
   }
 }

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -46,6 +46,8 @@ export class User extends BaseModel {
   hide_newsletter: boolean;
   is_in_newsletter: boolean;
   number_of_free_virtual_retreat: number;
+  get_number_of_past_tomatoes: number;
+  get_number_of_future_tomatoes: number;
 
   getUniversity() {
     if (this.university) {

--- a/src/app/services/reservation.service.ts
+++ b/src/app/services/reservation.service.ts
@@ -48,6 +48,9 @@ export class ReservationService extends GlobalService {
         if (filter.name === 'is_active') {
           params = params.set('is_active', filter.value);
         }
+        if (filter.name === 'timeslot__end_time__gte') {
+          params = params.set('timeslot__end_time__gte', filter.value);
+        }
         if (filter.name === 'ordering') {
           params = params.set('ordering', filter.value);
         }

--- a/src/app/services/retreat-reservation.service.ts
+++ b/src/app/services/retreat-reservation.service.ts
@@ -29,6 +29,8 @@ export class RetreatReservationService extends GlobalService {
           params = params.set('retreat', filter.value);
         } else if (filter.name === 'is_active') {
           params = params.set('is_active', filter.value);
+        } else if (filter.name === 'finish_after') {
+          params = params.set('finish_after', filter.value);
         } else if (filter.name === 'retreat__type__is_virtual') {
           params = params.set('retreat__type__is_virtual', filter.value);
         }


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | [Ticket 2771](https://redmine.fjnr.ca/issues/2771)

---

## What have you changed ?
Get number of tomatoes from API in place of frontend calculation
Load only future retreat by default and load others only on demand

## How did you change it ?
Nothing special, just refactor the profile page

## Screenshots
Nothing changed on design

## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
