### PR TITLE
show retreat on display start date if existing

### DIFF
--- a/src/app/components/pages/retreat/retreat-reservation/retreat-reservation-summary/retreat-reservation-summary.component.ts
+++ b/src/app/components/pages/retreat/retreat-reservation/retreat-reservation-summary/retreat-reservation-summary.component.ts
@@ -77,9 +77,15 @@ export class RetreatReservationSummaryComponent implements OnInit {
   filterRetreat(month = this.month, year = this.year) {
     const newFilteredList = [];
     for (const retreat of this.retreats) {
+      if (retreat.getDisplayStartDate()) {
+        if (retreat.getDisplayStartDate().getMonth() === month && retreat.getDisplayStartDate().getFullYear() === year) {
+          newFilteredList.push(retreat);
+        }
+      } else {
         if (retreat.getStartDate().getMonth() === month && retreat.getStartDate().getFullYear() === year) {
           newFilteredList.push(retreat);
         }
+      }
     }
     this.filteredRetreats.emit(newFilteredList);
     this.summaryList = newFilteredList;

--- a/src/app/models/retreat.ts
+++ b/src/app/models/retreat.ts
@@ -51,6 +51,7 @@ export class Retreat extends BaseModel {
   price: number;
   start_time: string;
   end_time: string;
+  display_start_time: string;
   min_day_refund: number;
   refund_rate: number;
   min_day_exchange: number;
@@ -123,6 +124,14 @@ export class Retreat extends BaseModel {
 
   getEndDate() {
     return new Date(this.end_time);
+  }
+
+  getDisplayStartDate() {
+    if (this.display_start_time) {
+      return new Date(this.display_start_time);
+    } else {
+      return null;
+    }
   }
 
   getStartDay() {


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | [2523](https://redmine.fjnr.ca/issues/2523)

---

## What have you changed ?
Display retreat on the month asked with display_start_time field

## How did you change it ?
Refactor of summary retreat logic that split the retreat by months

## Screenshots
No changes on design

## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
