### PR TITLE
Add cart toggle in profile and virtuel-activties

### DIFF
--- a/src/app/components/pages/profile/profile.component.html
+++ b/src/app/components/pages/profile/profile.component.html
@@ -1,6 +1,9 @@
 <app-loader *ngIf="!profile"></app-loader>
 
 <div class="profile-page" *ngIf="profile">
+  <app-cart-button *ngIf="displayCartButton$ | async"
+                   class="profile-page__cart-button"
+                   (onClick)="openCart()"></app-cart-button>
   <app-profile-reservation-open *ngIf="openVirtualReservation" [reservation]="openVirtualReservation"></app-profile-reservation-open>
   <div class="profile-page__body">
     <h1 class="profile-page__body__title">

--- a/src/app/components/pages/profile/profile.component.scss
+++ b/src/app/components/pages/profile/profile.component.scss
@@ -4,6 +4,13 @@
   background-color: white;
   min-height: 100vh;
 
+  &__cart-button {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 1;
+  }
+
   &__reservation-open {
     display: flex;
     background-color: $nt-14;

--- a/src/app/components/pages/profile/profile.component.ts
+++ b/src/app/components/pages/profile/profile.component.ts
@@ -1,19 +1,34 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {User} from '../../../models/user';
 import {AuthenticationService} from '../../../services/authentication.service';
 import {RetreatReservation} from '../../../models/retreatReservation';
+import {Observable, Subscription} from 'rxjs';
+import {RightPanelService} from '../../../services/right-panel.service';
+import {Router} from '@angular/router';
 
 @Component({
   selector: 'app-profile',
   templateUrl: './profile.component.html',
   styleUrls: ['./profile.component.scss']
 })
-export class ProfileComponent implements OnInit {
+export class ProfileComponent implements OnInit, OnDestroy {
 
   profile: User;
   openVirtualReservation: RetreatReservation;
+  displayCartButton$: Observable<boolean> = this._rightPanelService.displayCartButton$;
+  finalizeSubscription: Subscription;
 
-  constructor(private authenticationService: AuthenticationService) { }
+  constructor(
+    private authenticationService: AuthenticationService,
+    private _rightPanelService: RightPanelService,
+    private router: Router) {
+
+    this.finalizeSubscription = this._rightPanelService.finalize$.subscribe(
+      () => {
+        this.finalize();
+      }
+    );
+  }
 
   ngOnInit() {
     this.profile = this.authenticationService.getProfile();
@@ -29,5 +44,18 @@ export class ProfileComponent implements OnInit {
 
   getTotalFutureTomatoes() {
     return this.profile.get_number_of_future_tomatoes;
+  }
+
+  finalize() {
+    this.router.navigate(['/payment']).then();
+  }
+
+  openCart() {
+    this._rightPanelService.openCartPanel();
+  }
+
+  ngOnDestroy(): void {
+    this._rightPanelService.closePanel();
+    this.finalizeSubscription.unsubscribe();
   }
 }

--- a/src/app/components/pages/virtual-activities/virtual-activities.component.html
+++ b/src/app/components/pages/virtual-activities/virtual-activities.component.html
@@ -1,4 +1,7 @@
 <div class="virtual-activities">
+  <app-cart-button *ngIf="displayCartButton$ | async"
+                   class="virtual-activities__cart-button"
+                   (onClick)="openCart()"></app-cart-button>
   <div class="virtual-activities__main">
     <div class="virtual-activities__main__content">
       <div class="virtual-activities__main__content__header">

--- a/src/app/components/pages/virtual-activities/virtual-activities.component.ts
+++ b/src/app/components/pages/virtual-activities/virtual-activities.component.ts
@@ -1,17 +1,34 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {RetreatTypeService} from '../../../services/retreat-type.service';
 import {RetreatType} from '../../../models/retreatType';
+import {Observable, Subscription} from 'rxjs';
+import {RightPanelService} from '../../../services/right-panel.service';
+import {AuthenticationService} from '../../../services/authentication.service';
+import {Router} from '@angular/router';
 
 @Component({
   selector: 'app-virtual-activities',
   templateUrl: './virtual-activities.component.html',
   styleUrls: ['./virtual-activities.component.scss']
 })
-export class VirtualActivitiesComponent implements OnInit {
+export class VirtualActivitiesComponent implements OnInit, OnDestroy {
 
   retreatTypes: RetreatType[];
+  displayCartButton$: Observable<boolean> = this._rightPanelService.displayCartButton$;
+  finalizeSubscription: Subscription;
 
-  constructor(private retreatTypeService: RetreatTypeService) { }
+  constructor(
+    private retreatTypeService: RetreatTypeService,
+    private authenticationService: AuthenticationService,
+    private _rightPanelService: RightPanelService,
+    private router: Router) {
+
+    this.finalizeSubscription = this._rightPanelService.finalize$.subscribe(
+      () => {
+        this.finalize();
+      }
+    );
+  }
 
   ngOnInit() {
     const filter = [
@@ -25,6 +42,19 @@ export class VirtualActivitiesComponent implements OnInit {
         this.retreatTypes = retreatTypes.results.map(o => new RetreatType(o));
       }
     );
+  }
+
+  finalize() {
+    this.router.navigate(['/payment']).then();
+  }
+
+  openCart() {
+    this._rightPanelService.openCartPanel();
+  }
+
+  ngOnDestroy(): void {
+    this._rightPanelService.closePanel();
+    this.finalizeSubscription.unsubscribe();
   }
 
 }

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -64,5 +64,6 @@ export const environment = {
     retreat_waiting_queue_notifications: '/retreat/wait_queue_notifications',
     retreat_invitation: '/retreat/retreat_invitation',
     urlCKEditorPage: '/ckeditor_page',
+    retreatLogActivity: '/retreat/retreat_usage_log',
   }
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -64,5 +64,6 @@ export const environment = {
     retreat_waiting_queue_notifications: '/retreat/wait_queue_notifications',
     retreat_invitation: '/retreat/retreat_invitation',
     urlCKEditorPage: '/ckeditor_page',
+    retreatLogActivity: '/retreat/retreat_usage_log',
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -69,5 +69,6 @@ export const environment = {
     retreat_waiting_queue_notifications: '/retreat/wait_queue_notifications',
     retreat_invitation: '/retreat/retreat_invitation',
     urlCKEditorPage: '/ckeditor_page',
+    retreatLogActivity: '/retreat/retreat_usage_log',
   }
 };


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Enhancement]
| Tickets (_issues_) concerned               | [ticket 2522](https://redmine.fjnr.ca/issues/2522)

---

## What have you changed ?
Rajouter le toggle pour le panier sur deux pages : profil et la page qui présente les services virtuels

## How did you change it ?
Incorporation du toggle dans le html, ajout des function dans le typescript et ajout des classe dans le css si manquant

## Screenshots
Page profil : 
![image](https://user-images.githubusercontent.com/62400768/119552051-495cd080-bd68-11eb-961a-62412ae58142.png)
![image](https://user-images.githubusercontent.com/62400768/119552099-5aa5dd00-bd68-11eb-84c4-67d4d9cfdfa0.png)

Page virtuel : 
![image](https://user-images.githubusercontent.com/62400768/119552200-71e4ca80-bd68-11eb-9503-f813557b79f5.png)
![image](https://user-images.githubusercontent.com/62400768/119552147-65f90880-bd68-11eb-8247-375a55fbdf6b.png)


## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 
