### PR TITLE
fix display join virtual retreat

### DIFF
--- a/src/app/components/pages/profile/profile-retreats/profile-retreats.component.ts
+++ b/src/app/components/pages/profile/profile-retreats/profile-retreats.component.ts
@@ -162,6 +162,12 @@ export class ProfileRetreatsComponent implements OnInit {
             this.listReservationToAdmin.push(retreatReservation);
           }
         }
+
+        for (const reservation of this.listFutureRetreatReservations) {
+          if (reservation.retreat_details.isOpen) {
+            this.openVirtualReservation.emit(reservation);
+          }
+        }
       }
     );
   }


### PR DESCRIPTION
The panel to join virtual retreat was not visible on first display of the page since we created a new function to show only the future retreat