### PR TITLE
add number of tomatoes on retreat preview

### DIFF
--- a/src/app/components/shared/retreat-preview/retreat-preview.component.html
+++ b/src/app/components/shared/retreat-preview/retreat-preview.component.html
@@ -28,8 +28,10 @@
       <app-link text="{{ retreat.place_name }} ({{ retreat.city }})" [href]="retreat.google_maps_url" target="_blank"></app-link>
     </div>
     <div class="retreat-preview__infos__line" *ngIf="retreat.type.is_virtual">
-      <app-title [level]='5' text="{{'retreat-preview.videoconference_tool' | translate}}"></app-title>
-      <app-title [level]='9' [text]="retreat.videoconference_tool"></app-title>
+      <app-title [level]='5' text="{{'retreat-preview.number_of_tomatoes' | translate}}"></app-title>
+      <div style="display: flex; align-items: center">
+        <app-title [level]='9' [text]="retreat.numberOfTomatoes"></app-title><i class="icon icon-tomato icon--3x"></i>
+      </div>
     </div>
     <div class="retreat-preview__infos__line">
       <app-title [level]='5' text="{{'retreat-preview.space_available' | translate}}"></app-title>

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -953,6 +953,7 @@
   "retreat-preview.success": "Liste d'attente",
   "retreat-preview.to_register": "S'inscrire",
   "retreat-preview.videoconference_tool": "Outil",
+  "retreat-preview.number_of_tomatoes": "Nombre de tomates",
   "retreat-reservation-model.cancelation_action.exchange": "Échange",
   "retreat-reservation-model.cancelation_action.refund": "Remboursement",
   "retreat-reservation-model.cancelation_reason.admin_cancellation": "Annulation par un.e administrateur.trice",


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | [3042](https://redmine.fjnr.ca/issues/3042)

---

## What have you changed ?
Replace videoconference info by number of tomatoes on retreat preview

## How did you change it ?
Nothing special

## Screenshots
![Capture](https://user-images.githubusercontent.com/12053720/122452048-d4e80c80-cf76-11eb-8eba-dda16869d730.PNG)


## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
