### PR TITLE
Correction field in env QA

### DIFF
--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -9,7 +9,7 @@ export const environment = {
   // tslint:disable-next-line:max-line-length
   token_paysafe: 'T1QtMjMxODcwOkItcWEyLTAtNWI4NmUxMDktMC0zMDJjMDIxNDJiMWI4YjNjZmMyNmM0YTc3ZTUzNTI0YjYzNzEwMzU3YWE1NmYzNWMwMjE0NjM5N2ZhZTJiMDZjNjFiYmFhNGQ1NGZjNDE2MjlhOGIxNzVmOTRhNw==',
   defaultWorkplaceId: 6,
-  retreatTypeBlocId: 4,
+  retreatTypeBlocId: 2,
   defaultRetreatId: 1,
   canHideFooter: false,
   paths_api: {


### PR DESCRIPTION
J'ai modifier lle champs "defaultRetreatId" pour qu'il corresponde à l'id du bloc virtuel qui est dans la nouvelle API de QA
